### PR TITLE
Hide unavailable occurrences

### DIFF
--- a/components/occurrence/List.vue
+++ b/components/occurrence/List.vue
@@ -82,10 +82,10 @@ const showHidden = useState(`occurrence-list--${props.mensa}-${props.date}-sh`, 
 const occurrences = computed(() => {
   if (loading.value) return { visible: [], hidden: [] }
 
-  let unavailable = data.value.occurrences.filter(o => o.notAvailableAfter != null)
+  const unavailable = data.value.occurrences.filter(o => o.notAvailableAfter != null)
   // Only filter the available occurrences, as the other ones will be hidden anyway
-  let {visible, hidden} = filters.filterOccurrences(data.value.occurrences.filter(o => o.notAvailableAfter == null))
-  return { visible, hidden: hidden.concat(unavailable) }
+  const {visible, hidden} = filters.filterOccurrences(data.value.occurrences.filter(o => o.notAvailableAfter == null))
+  return { visible, hidden: [...hidden, ...unavailable] }
 })
 
 function toggleHiddenItems() {

--- a/components/occurrence/List.vue
+++ b/components/occurrence/List.vue
@@ -81,7 +81,11 @@ const showHidden = useState(`occurrence-list--${props.mensa}-${props.date}-sh`, 
 
 const occurrences = computed(() => {
   if (loading.value) return { visible: [], hidden: [] }
-  return filters.filterOccurrences(data.value.occurrences)
+
+  let unavailable = data.value.occurrences.filter(o => o.notAvailableAfter != null)
+  // Only filter the available occurrences, as the other ones will be hidden anyway
+  let {visible, hidden} = filters.filterOccurrences(data.value.occurrences.filter(o => o.notAvailableAfter == null))
+  return { visible, hidden: hidden.concat(unavailable) }
 })
 
 function toggleHiddenItems() {

--- a/utils/entities/occurrence.ts
+++ b/utils/entities/occurrence.ts
@@ -36,6 +36,7 @@ export namespace EntityOccurrence {
       priceStudent
       priceStaff
       priceGuest
+      notAvailableAfter
       tags {
         key
         name
@@ -93,6 +94,7 @@ export namespace EntityOccurrence {
     priceStudent: number
     priceStaff: number
     priceGuest: number
+    notAvailableAfter: string
     tags: Tag[]
   }
 


### PR DESCRIPTION
Unavailable dishes (on a day) should be indicated a bit more intuitively in the future.
Hiding them is still fine for now, as the view does get very messy when multiple dishes are replaced on a day.