### PR TITLE
feat: Change mensa (fav) highlighting

### DIFF
--- a/components/popup/SelectMensa.vue
+++ b/components/popup/SelectMensa.vue
@@ -93,7 +93,7 @@ function toggleFav(location: EntityLocation.Location) {
 
   &[data-fav=true] {
     .fav {
-      color: $color-red;
+      color: $color-green;
     }
   }
 

--- a/components/popup/SelectMensa.vue
+++ b/components/popup/SelectMensa.vue
@@ -92,18 +92,16 @@ function toggleFav(location: EntityLocation.Location) {
   }
 
   &[data-fav=true] {
-    background-color: $color-green20;
-
-    .name {
-      color: $color-major;
-    }
-
     .fav {
-      color: $color-green;
+      color: $color-red;
     }
   }
 
-  [view-mode=desktop] &[data-fav=true]:hover {
+  &[data-selected=true] {
+    background-color: $color-green20;
+  }
+
+  [view-mode=desktop] &[data-selected=true]:hover {
     background-color: $color-green40;
   }
 


### PR DESCRIPTION
![image](https://github.com/mensatt/frontend/assets/58337328/fdd47a7e-142f-49e9-a006-3731723a2f10)

Bin nicht 100% zufrieden, aber finde es besser als davor (selection = grün, herzen = rot :3)

Zu lösendes Problem war, dass die selektierte Option nicht erkennbar ist und mit der grünen Hinterlegung der gefavten Optionen verwirrend ist. Allerdings ist der Ansatz hier potentiell auch ein bisschen komisch, da jetzt die gefavten Optionen in den Hintergrund rücken,

Thoughts?